### PR TITLE
Fix the example usage of 'set'

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ with the modifications applied.
 ```js
 data = { bob: { name: 'Bob' } }
 db = scour(data)
-db.set([ 'bob', 'name' ], 'Robert')
+db = db.set([ 'bob', 'name' ], 'Robert')
 // db.value == { bob: { name: 'Robert' } }
 ```
 


### PR DESCRIPTION
I noticed that this example was depicting that the scour instance was modified "in-place" when using `set`, even though the statement above the example says it returns the modified state. This came to my attention after I tried using `set` as it was shown in the example.