### PR TITLE
Check presence of value before valueOf to allow null as a value for set

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -497,7 +497,8 @@ scour.prototype = {
     }
 
     // use .valueOf() to denature any scour-wrapping or String() or whatnot
-    const result = scour.set(this.value || {}, keypath, value.valueOf())
+    value = value && value.valueOf() || value
+    const result = scour.set(this.value || {}, keypath, value)
 
     // Update indices, if any
     let indices = updateIndices(this.indices, result, keypath)

--- a/test/scour/set_test.js
+++ b/test/scour/set_test.js
@@ -72,3 +72,13 @@ test('.set() with wrapping', (t) => {
 
   t.end()
 })
+
+test('.set() null', (t) => {
+  var data = { bob: { name: 'Bob' } }
+  var result = scour(data).set('bob.name', null)
+
+  t.deepEqual(
+    result.value,
+    { bob: { name: null } })
+  t.end()
+})


### PR DESCRIPTION
Issue: https://github.com/rstacruz/scour/issues/119

As explained in the issue, I want to be able to pass null as a value to set directly, instead of having to check the value and conditionally setting/deleting. Currently, scour crashes when trying to call `valueOf` on a null. 

I've added a presence check before the valueOf call to support null assignment. 